### PR TITLE
Add support for Notion defined colours

### DIFF
--- a/nprompter/processing/processor.py
+++ b/nprompter/processing/processor.py
@@ -130,6 +130,8 @@ class HtmlNotionProcessor:
         return block_contents
 
     def process_paragraph(self, block, block_type, tag_name):
+        notion_color = block[block_type].get("color", "default")
+        base_classes = [block_type, f"notion-{notion_color}"]
         contents = block[block_type].get("text", block[block_type].get("rich_text", []))
         paragraph_content_tags = []
         for content in contents:
@@ -137,7 +139,7 @@ class HtmlNotionProcessor:
                 text_content = text["content"].replace("\n", "<br />")
                 annotations = content["annotations"]
                 annotations_tags = ["bold", "italic", "strikethrough", "underline", "code"]
-                classes = " ".join([block_type] + [tag for tag in annotations_tags if annotations.get(tag)])
+                classes = " ".join(base_classes + [tag for tag in annotations_tags if annotations.get(tag)])
                 tag = f'<span class="{classes}">{text_content}</span>'
                 paragraph_content_tags.append(tag)
             elif equation := content.get("equation"):

--- a/nprompter/web/templates/nprompter.css
+++ b/nprompter/web/templates/nprompter.css
@@ -105,3 +105,85 @@ span.code {
     border-radius: 10px;
     padding: 0 10px;
 }
+
+/* Notion coloured blocks */
+
+.notion-black {
+	color: rgb(0, 0, 0);
+}
+
+.notion-black_background {
+	background-color: rgb(0, 0, 0, 0.7);
+}
+
+.notion-gray {
+	color: rgb(128, 128, 128);
+}
+
+.notion-gray_background {
+	background-color: rgb(128, 128, 128, 0.7);
+}
+
+.notion-brown {
+	color: rgb(165, 42, 42);
+}
+
+.notion-brown_background {
+	background-color: rgb(165, 42, 42, 0.7);
+}
+
+.notion-orange {
+	color: rgb(255, 165, 0);
+}
+
+.notion-orange_background {
+	background-color: rgb(255, 165, 0, 0.7);
+}
+
+.notion-yellow {
+	color: rgb(255, 255, 0);
+}
+
+.notion-yellow_background {
+	background-color: rgb(255, 255, 0, 0.7);
+}
+
+.notion-green {
+	color: rgb(0, 128, 0);
+}
+
+.notion-green_background {
+	background-color: rgb(0, 128, 0, 0.7);
+}
+
+.notion-blue {
+	color: rgb(0, 0, 255);
+}
+
+.notion-blue_background {
+	background-color: rgb(0, 0, 255, 0.7);
+}
+
+.notion-purple {
+	color: rgb(128, 0, 128);
+}
+
+.notion-purple_background {
+	background-color: rgb(128, 0, 128, 0.7);
+}
+
+.notion-pink {
+	color: rgb(255, 192, 203);
+}
+
+.notion-pink_background {
+	background-color: rgb(255, 192, 203, 0.7);
+}
+
+.notion-red {
+	color: rgb(255, 0, 0);
+}
+
+.notion-red_background {
+	background-color: rgb(255, 0, 0, 0.7);
+}


### PR DESCRIPTION
I made these using the following Python code using _colour_.

```python
from colour import Color

colors = [
    "gray",
    "brown",
    "orange",
    "yellow",
    "green",
    "blue",
    "purple",
    "pink",
    "red",
]

colours = {
    'default': Color("black"),
    **{
        color: Color(color) for color in colors
    }
}

styles = []

for c, color in colours.items():
    r, g ,b = [round(255 * part) for part in color.get_rgb()]
    styles.append(f".notion-{color} {{\n\tcolor: rgb({r}, {g}, {b});\n}}")
    styles.append(f".notion-{color}_background {{\n\tbackground-color: rgb({r}, {g}, {b}, 0.7);\n}}")

print("\n\n".join(styles))
```