### PR TITLE
Skip on break

### DIFF
--- a/nprompter/processing/processor.py
+++ b/nprompter/processing/processor.py
@@ -211,6 +211,12 @@ class HtmlNotionProcessor:
         for content in contents:
             if text := content.get("text"):
                 text_content = text["content"].replace("\n", "<br />")
+                if (
+                    text_content.startswith("[")
+                    and text_content.endswith("]")
+                    and self.configuration["processor"]["skip_square_brackets"]
+                ):
+                    continue
                 annotations = content["annotations"]
                 annotations_tags = ["bold", "italic", "strikethrough", "underline", "code"]
                 classes = " ".join(base_classes + [tag for tag in annotations_tags if annotations.get(tag)])

--- a/nprompter/web/assets/app.js
+++ b/nprompter/web/assets/app.js
@@ -174,7 +174,9 @@ const controls = {
     73: [debugInfo, "Show debug info to the console", 'I'], // I key
     77: [mirrorScreen, "Mirror screen", 'M'], // M key
     49: [scrollToTop, "Scroll to top", '1'], // X key
-
+    82: [pageRefresh, "Refresh page", 'R'], // R key
+    191: [historyGoBack, "Go back", '/'], // / key
+    
     // Presenter mode controls
     27: [scrollUpManually, "Manual scroll up", "ESC"],
     66: [scrollDownManually, "Scroll down manually", 'B'],
@@ -237,4 +239,13 @@ function showInfo(message) {
               snackbar.className = snackbar.className.replace("show", "");
          }, snackbarTimeout);
    }
+}
+
+function historyGoBack() {
+    history.back();
+    return "Navigated back"
+}
+
+function pageRefresh() {
+    window.location.reload();
 }

--- a/nprompter/web/nprompter.toml
+++ b/nprompter/web/nprompter.toml
@@ -9,6 +9,7 @@ family = "'Roboto', sans-serif"
 [processor]
 skip_on_break = false
 hide_non_default_colors = false
+skip_square_brackets = false
 render_code = "placeholder"
 
 [screen]

--- a/nprompter/web/templates/base.html
+++ b/nprompter/web/templates/base.html
@@ -18,7 +18,6 @@
         <link rel="shortcut icon" href="/favicon.ico" />
         <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
         <link rel="manifest" href="/manifest.json">
-        <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
         <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>
     </head>
     <body>


### PR DESCRIPTION
This pull request includes several changes to improve the functionality and user experience of the `nprompter` project. The most important changes include adding new keyboard shortcuts, enhancing the text processing logic, and updating the configuration file.

### Enhancements to keyboard shortcuts:

* [`nprompter/web/assets/app.js`](diffhunk://#diff-347bcb6970477b52b8b3dc5ef74d599b4b6a9b13b5f7b57dbba4764e52f409f8R177-R178): Added new keyboard shortcuts for refreshing the page (`R` key) and navigating back in history (`/` key). [[1]](diffhunk://#diff-347bcb6970477b52b8b3dc5ef74d599b4b6a9b13b5f7b57dbba4764e52f409f8R177-R178) [[2]](diffhunk://#diff-347bcb6970477b52b8b3dc5ef74d599b4b6a9b13b5f7b57dbba4764e52f409f8R243-R251)

### Improvements to text processing:

* [`nprompter/processing/processor.py`](diffhunk://#diff-ad03c14bbaf2b5914f38ac460a62dafbe31666ff243c0545bfdf57297b99d91eR214-R215): Updated the `process_paragraph` method to skip processing text enclosed in square brackets when the `skip_square_brackets` configuration is enabled.

### Configuration file update:

* [`nprompter/web/nprompter.toml`](diffhunk://#diff-12bf900951521e8923387a4e5f32ef4b8f3dc8955f9adc411b898a86290c5a0bR12): Added a new configuration option `skip_square_brackets` to control the skipping of text enclosed in square brackets.

### Minor changes:

* [`nprompter/web/templates/base.html`](diffhunk://#diff-bb31d7033a981cebdba940bae7b45967d4bda2c2611fec1cbef71ee1c7e718cfL21): Removed the polyfill script for ES6 features as it is no longer needed.