### PR TITLE
Migrate to new notion api

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,4 +29,6 @@ jobs:
     - name: Run Black
       run: uv run black . --check
     - name: Run tests
+      env:
+        NOTION_API_KEY: ${{ secrets.NPROMPTER_TEST_NOTION_API_KEY }}
       run: uv run pytest

--- a/nprompter/__init__.py
+++ b/nprompter/__init__.py
@@ -1,2 +1,2 @@
 __version__ = "4.3.0"
-__notion_version__ = "2022-02-22"
+__notion_version__ = "2025-09-03"

--- a/nprompter/api/notion_client.py
+++ b/nprompter/api/notion_client.py
@@ -43,6 +43,8 @@ class NotionClient:
             f"https://api.notion.com/v1/data_sources/{data_source_id}",
             headers=self.headers,
         ).json()
+        if data_source.get("object") == "error":
+            raise ValueError(f"{data_source['code']} - {data_source['message']}")
         return data_source
 
     def get_pages(self, data_source_id: str, property_filter: str, property_value: str) -> List[Dict]:

--- a/nprompter/api/notion_client.py
+++ b/nprompter/api/notion_client.py
@@ -25,17 +25,30 @@ class NotionClient:
             "Notion-Version": notion_version,
         }
 
-    def get_database(self, database_id: str) -> Dict:
+    def get_data_source_from_database(self, database_id: str) -> Dict:
         database = requests.get(
             f"https://api.notion.com/v1/databases/{database_id}",
             headers=self.headers,
         ).json()
-        return database
 
-    def get_pages(self, database_id: str, property_filter: str, property_value: str) -> List[Dict]:
+        if data_sources := database.get("data_sources"):
+            if len(data_sources) > 1:
+                # TODO: Handle multiple data sources
+                pass
+            data_source_id = data_sources[0]["id"]
+        else:
+            raise ValueError(f"Database {database_id} has no data sources")
+
+        data_source = requests.get(
+            f"https://api.notion.com/v1/data_sources/{data_source_id}",
+            headers=self.headers,
+        ).json()
+        return data_source
+
+    def get_pages(self, data_source_id: str, property_filter: str, property_value: str) -> List[Dict]:
         query = build_filter_query([(property_filter, "equals", property_value)])
         database = requests.post(
-            f"https://api.notion.com/v1/databases/{database_id}/query",
+            f"https://api.notion.com/v1/data_sources/{data_source_id}/query",
             json=query,
             headers=self.headers,
         ).json()

--- a/nprompter/processing/processor.py
+++ b/nprompter/processing/processor.py
@@ -98,18 +98,18 @@ class HtmlNotionProcessor:
         return db
 
     def _process_single_database(self, database_id: str, config: Dict):
-        database = self.notion_client.get_database(database_id)
+        data_source = self.notion_client.get_data_source_from_database(database_id)
         pages = self.notion_client.get_pages(
-            database_id=database_id,
+            data_source_id=data_source["id"],
             property_filter=config["build"]["filter"]["property"],
             property_value=config["build"]["filter"]["value"],
         )
         # Create database folder
         (self.output_folder / database_id).mkdir(exist_ok=True)
-        database_dict = {"id": database_id, "title": database["title"][0]["plain_text"], "scripts": []}
+        database_dict = {"id": database_id, "title": data_source["title"][0]["plain_text"], "scripts": []}
 
         sort_property = config["build"]["sort"]["property"]
-        sort_property_definition = database["properties"][sort_property]
+        sort_property_definition = data_source["properties"][sort_property]
         sort_property_type = sort_property_definition["type"]
         if sort_property_type in ["title", "rich_text"]:
             pages = sorted(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ nprompter = "nprompter.__main__:app"
 
 [dependency-groups]
 dev = [
+    "beautifulsoup4>=4.14.2",
     "black>=25.9.0",
     "bump2version>=1.0.1",
     "commitizen>=4.9.1",

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -10,7 +10,6 @@ runner = CliRunner()
 
 def test_app(tmp_path: Path):
     result = runner.invoke(app, ["build", "c68ccc052d1b4eaaa3091e637f7011c0", "--output", tmp_path])
-    breakpoint()
     assert result.exit_code == 0, result.output
     assert (tmp_path / "index.html").exists()
     with open(tmp_path / "index.html", "r") as file:

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+from bs4 import BeautifulSoup
+from typer.testing import CliRunner
+
+from nprompter.__main__ import app
+
+runner = CliRunner()
+
+
+def test_app(tmp_path: Path):
+    result = runner.invoke(app, ["build", "c68ccc052d1b4eaaa3091e637f7011c0", "--output", tmp_path])
+    breakpoint()
+    assert result.exit_code == 0, result.output
+    assert (tmp_path / "index.html").exists()
+    with open(tmp_path / "index.html", "r") as file:
+        soup = BeautifulSoup(file, "html.parser")
+        assert soup.find("h2").text == "Example board"
+        pages = soup.find("ul").find_all("li")
+        assert len(pages) == 7

--- a/uv.lock
+++ b/uv.lock
@@ -44,6 +44,19 @@ wheels = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.14.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "soupsieve" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/e9/df2358efd7659577435e2177bfa69cba6c33216681af51a707193dec162a/beautifulsoup4-4.14.2.tar.gz", hash = "sha256:2a98ab9f944a11acee9cc848508ec28d9228abfd522ef0fad6a02a72e0ded69e", size = 625822, upload-time = "2025-09-29T10:05:42.613Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/fe/3aed5d0be4d404d12d36ab97e2f1791424d9ca39c2f754a6285d59a3b01d/beautifulsoup4-4.14.2-py3-none-any.whl", hash = "sha256:5ef6fa3a8cbece8488d66985560f97ed091e22bbc4e9c2338508a9d5de6d4515", size = 106392, upload-time = "2025-09-29T10:05:43.771Z" },
+]
+
+[[package]]
 name = "black"
 version = "25.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -546,7 +559,7 @@ wheels = [
 
 [[package]]
 name = "nprompter"
-version = "4.2.0"
+version = "4.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },
@@ -558,6 +571,7 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "beautifulsoup4" },
     { name = "black" },
     { name = "bump2version" },
     { name = "commitizen" },
@@ -579,6 +593,7 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "beautifulsoup4", specifier = ">=4.14.2" },
     { name = "black", specifier = ">=25.9.0" },
     { name = "bump2version", specifier = ">=1.0.1" },
     { name = "commitizen", specifier = ">=4.9.1" },
@@ -888,6 +903,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/75/a7/9810d872919697c9d01295633f5d574fb416d47e535f258272ca1f01f447/snowballstemmer-3.0.1.tar.gz", hash = "sha256:6d5eeeec8e9f84d4d56b847692bacf79bc2c8e90c7f80ca4444ff8b6f2e52895", size = 105575, upload-time = "2025-05-09T16:34:51.843Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/78/3565d011c61f5a43488987ee32b6f3f656e7f107ac2782dd57bdd7d91d9a/snowballstemmer-3.0.1-py3-none-any.whl", hash = "sha256:6cd7b3897da8d6c9ffb968a6781fa6532dce9c3618a4b127d920dab764a19064", size = 103274, upload-time = "2025-05-09T16:34:50.371Z" },
+]
+
+[[package]]
+name = "soupsieve"
+version = "2.8"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/e6/21ccce3262dd4889aa3332e5a119a3491a95e8f60939870a3a035aabac0d/soupsieve-2.8.tar.gz", hash = "sha256:e2dd4a40a628cb5f28f6d4b0db8800b8f581b65bb380b97de22ba5ca8d72572f", size = 103472, upload-time = "2025-08-27T15:39:51.78Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/a0/bb38d3b76b8cae341dad93a2dd83ab7462e6dbcdd84d43f54ee60a8dc167/soupsieve-2.8-py3-none-any.whl", hash = "sha256:0cc76456a30e20f5d7f2e14a98a4ae2ee4e5abdc7c5ea0aafe795f344bc7984c", size = 36679, upload-time = "2025-08-27T15:39:50.179Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request updates the Notion API integration to support the newest Notion data source model and adds a test for the CLI build command. 

**Notion API integration updates:**

* Updated the internal Notion API version to `2025-09-03` in `__init__.py` to support the latest features.
* Refactored `NotionClient` methods: replaced `get_database` with `get_data_source_from_database` to fetch and use data sources, and updated `get_pages` to query data sources instead of databases.
* Updated the processor logic to use data sources throughout, including retrieving pages and database metadata from the data source object instead of the database object.

**Development tooling and testing:**

* Added `beautifulsoup4` as a development dependency in `pyproject.toml` for HTML parsing in tests.
* Introduced a new test in `tests/test_build.py` that uses Typer's `CliRunner` and BeautifulSoup to verify the CLI build command produces the expected HTML output.