### PR TITLE
Improved output

### DIFF
--- a/docs/nprompter/usage.md
+++ b/docs/nprompter/usage.md
@@ -29,10 +29,14 @@ The build command takes several *optional* parameters that allow for great custo
 
  * `-o [PATH]` / `--output [PATH]`: to specify where the output should be written to. Defaults to *"./prompter"*.  
  * `-f [STRING]` / `--filter [STRING]`: Nprompter fetches data from a Notion database filtering by properties and specific values, use this to specify which property to filter by. Defaults to *"Status"*.
- * `-v [STRING]` / `--value [STRING]`: Nprompter fetches data from a Notion database filtering by properties and specific values, use this to specify which value to search for. Defaults to *"Ready"*.
+ * `--value [STRING]`: Nprompter fetches data from a Notion database filtering by properties and specific values, use this to specify which value to search for. Defaults to *"Ready"*.
  * `-c [PATH]` / `--config [PATH]`: Specifies the location of a configuration file. Defaults to *None*. See the [syntax](./configuration-file.md) of the configuration file for more information.
- * `-s [PATH]` / `--extra-css [PATH]`: Specifies the location of an additional CSS file to further customize the teleprompter's appereance. Defaults to *None*.  
+ * `--extra-css [PATH]`: Specifies the location of an additional CSS file to further customize the teleprompter's appereance. Defaults to *None*.  
  * `--download/--no-download`: A flag that specifies whether to download information from _Notion_ or simply regenerate the styles that accompany the teleprompter. Defaults to *--download*.
+ * `-q` / `--quiet`: Suppress all output except errors
+ * `-v` / `--verbose`: Increase verbosity (can be used multiple times: `-v`, `-vv`, `-vvv`)
+
+ > For more information about verbosity control, see the [verbosity documentation](./verbosity.md).
 
 ## `serve`
 
@@ -47,6 +51,8 @@ You can simply run `nprompter serve` without any arguments to use the defaults: 
 ### Options
 
  * `--browser/--no-browser`: Whether the command will attempt to open the computer's default browser pointing to the teleprompter's page. The default is *--browser*.
+ * `-q` / `--quiet`: Suppress all output except errors
+ * `-v` / `--verbose`: Increase verbosity (can be used multiple times: `-v`, `-vv`, `-vvv`)
 
 ## `create-config`
 
@@ -55,3 +61,5 @@ This command helps the user create a configuration file used to customise the be
 ### Options
 
  * `--override/--no-override`:  This flag allows the user to specify whether to override or not any existing `config.toml`. The default is set to `--no-override`.
+ * `-q` / `--quiet`: Suppress all output except errors
+ * `-v` / `--verbose`: Increase verbosity (can be used multiple times: `-v`, `-vv`, `-vvv`)

--- a/nprompter/__main__.py
+++ b/nprompter/__main__.py
@@ -13,6 +13,18 @@ import nprompter.web
 from nprompter.api.notion_client import NotionClient
 from nprompter.cli.defaults import DEFAULT_OUTPUT_PATH, DEFAULT_PORT
 from nprompter.cli.helpers import get_config
+from nprompter.cli.output import (
+    VerbosityLevel,
+    debug,
+    error,
+    info,
+    parse_verbosity,
+    progress,
+    set_verbosity,
+    success,
+    verbose,
+    warning,
+)
 from nprompter.processing.processor import HtmlNotionProcessor
 
 app = typer.Typer(add_completion=False)
@@ -29,7 +41,7 @@ def build(
         None, "--filter", "-f", help="The name of the Notion's page property to filter by"
     ),
     property_value: Optional[str] = typer.Option(
-        None, "--value", "-v", help="The value of the Notion's page property to filter by"
+        None, "--value", help="The value of the Notion's page property to filter by"
     ),
     sort_property: Optional[str] = typer.Option(
         None, "--sort", "-s", help="The name of the Notion's page property to sort documents by"
@@ -37,44 +49,77 @@ def build(
     configuration_file: Optional[Path] = typer.Option(
         None, "--config", "-c", help="A path to an appearance configuration file"
     ),
-    custom_css: Optional[Path] = typer.Option(None, "--extra-css", "-s", help="A path to extra css configuration"),
+    custom_css: Optional[Path] = typer.Option(None, "--extra-css", help="A path to extra css configuration"),
     download_database: bool = typer.Option(
         True, "--download/--no-download", help="Whether to sync with the Notion's database"
+    ),
+    quiet: bool = typer.Option(False, "--quiet", "-q", help="Suppress all output except errors"),
+    verbose_count: int = typer.Option(
+        0, "--verbose", "-v", count=True, help="Increase verbosity (use -v, -vv, or -vvv)"
     ),
 ):
     """
     Fetch a Notion database and create the teleprompter's pages from it
     """
+    # Set verbosity level
+    verbosity = parse_verbosity(quiet, verbose_count)
+    set_verbosity(verbosity)
 
-    config_dict = get_config(configuration_file)
+    debug(f"Starting build with verbosity level: {verbosity.name}")
+    debug(f"Output directory: {output}")
+    debug(f"Configuration file: {configuration_file}")
 
-    if property_filter is not None:
-        config_dict["build"]["filter"]["property"] = property_filter
-    if property_value is not None:
-        config_dict["build"]["filter"]["value"] = property_value
-    if sort_property is not None:
-        config_dict["build"]["sort"]["property"] = sort_property
-    if database_id is not None:
-        config_dict["build"]["database_id"] = database_id
-    if output is not None:
-        config_dict["build"]["output"] = str(output)
-    if custom_css is not None:
-        config_dict["build"]["custom_css"] = str(output)
+    try:
+        config_dict = get_config(configuration_file)
 
-    notion_version = os.getenv("NOTION_VERSION", nprompter.__notion_version__)
+        if property_filter is not None:
+            config_dict["build"]["filter"]["property"] = property_filter
+            verbose(f"Using filter property: {property_filter}")
+        if property_value is not None:
+            config_dict["build"]["filter"]["value"] = property_value
+            verbose(f"Using filter value: {property_value}")
+        if sort_property is not None:
+            config_dict["build"]["sort"]["property"] = sort_property
+            verbose(f"Using sort property: {sort_property}")
+        if database_id is not None:
+            config_dict["build"]["database_id"] = database_id
+            verbose(f"Processing database: {database_id}")
+        if output is not None:
+            config_dict["build"]["output"] = str(output)
+        if custom_css is not None:
+            config_dict["build"]["custom_css"] = str(custom_css)
+            verbose(f"Using custom CSS: {custom_css}")
 
-    notion_client = NotionClient(notion_api_key=notion_api_key, notion_version=notion_version)
-    processor = HtmlNotionProcessor(notion_client, output_folder=output, configuration=config_dict)
+        notion_version = os.getenv("NOTION_VERSION", nprompter.__notion_version__)
+        debug(f"Using Notion API version: {notion_version}")
 
-    processor.prepare_folder(config_dict)
+        progress("Connecting to Notion API...")
+        notion_client = NotionClient(notion_api_key=notion_api_key, notion_version=notion_version)
+        processor = HtmlNotionProcessor(notion_client, output_folder=output, configuration=config_dict)
 
-    if "custom_css" in config_dict["build"]:
-        processor.add_extra_style(custom_css)
+        progress("Preparing output folder...")
+        processor.prepare_folder(config_dict)
+        verbose(f"Output folder prepared: {output}")
 
-    if "databases" in config_dict["build"]:
-        processor.process_databases(config_dict)
-    elif download_database:
-        processor.process_database(config_dict["build"]["database_id"], config=config_dict, index_at_root=True)
+        if "custom_css" in config_dict["build"]:
+            progress("Adding custom CSS...")
+            processor.add_extra_style(custom_css)
+
+        if "databases" in config_dict["build"]:
+            progress("Processing multiple databases...")
+            processor.process_databases(config_dict)
+            success("Successfully processed all databases")
+        elif download_database:
+            db_id = config_dict["build"]["database_id"]
+            progress(f"Processing database: {db_id}")
+            processor.process_database(db_id, config=config_dict, index_at_root=True)
+            success(f"Successfully processed database: {db_id}")
+        else:
+            info("Skipping database download (--no-download flag set)")
+
+    except Exception as e:
+        error(f"Failed to build teleprompter: {str(e)}", err=e)
+        raise typer.Exit(code=1)
 
 
 @app.command()
@@ -82,37 +127,78 @@ def serve(
     port: int = typer.Argument(DEFAULT_PORT),
     content_directory: Path = typer.Argument(DEFAULT_OUTPUT_PATH),
     browser: bool = typer.Option(True, help="Whether to open a web browser pointing to the server's address"),
+    quiet: bool = typer.Option(False, "--quiet", "-q", help="Suppress all output except errors"),
+    verbose_count: int = typer.Option(
+        0, "--verbose", "-v", count=True, help="Increase verbosity (use -v, -vv, or -vvv)"
+    ),
 ):
     """
     Start a basic web server to display the teleprompter's pages.
     This a good option for a small scale deployment.
     """
+    # Set verbosity level
+    verbosity = parse_verbosity(quiet, verbose_count)
+    set_verbosity(verbosity)
+
+    debug(f"Starting server with verbosity level: {verbosity.name}")
+    debug(f"Port: {port}")
+    debug(f"Content directory: {content_directory}")
+
+    if not content_directory.exists():
+        error(f"Content directory does not exist: {content_directory}")
+        raise typer.Exit(code=1)
 
     class CustomHandler(SimpleHTTPRequestHandler):
         def __init__(self, *args, **kwargs):
             super().__init__(*args, directory=str(content_directory), **kwargs)
 
         def log_message(self, format: str, *args: Any) -> None:
-            pass
+            # Only log HTTP requests in verbose mode
+            if verbosity >= VerbosityLevel.VERBOSE:
+                debug(f"HTTP {format % args}")
 
     socketserver.TCPServer.allow_reuse_address = True
     with socketserver.TCPServer(("", port), CustomHandler) as httpd:
         location = f"http://localhost:{port}"
-        print(f"Serving at {location}")
+        info(f"Serving at {location}")
+        verbose(f"Content directory: {content_directory}")
         if browser:
+            verbose("Opening browser...")
             webbrowser.open(location)
-        httpd.serve_forever()
+        else:
+            verbose("Browser opening disabled")
+        info("Press Ctrl+C to stop the server")
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:
+            info("\nServer stopped")
 
 
 @app.command()
-def create_config(override: bool = False):
+def create_config(
+    override: bool = typer.Option(False, "--override", help="Override existing configuration file"),
+    quiet: bool = typer.Option(False, "--quiet", "-q", help="Suppress all output except errors"),
+    verbose_count: int = typer.Option(
+        0, "--verbose", "-v", count=True, help="Increase verbosity (use -v, -vv, or -vvv)"
+    ),
+):
+    """
+    Create a default configuration file.
+    """
+    # Set verbosity level
+    verbosity = parse_verbosity(quiet, verbose_count)
+    set_verbosity(verbosity)
+
+    config_path = nprompter.cli.defaults.DEFAULT_CONFIG_PATH
+    debug(f"Creating config file: {config_path}")
+
     config = importlib.resources.read_text(nprompter.web, nprompter.cli.defaults.DEFAULT_CONFIG_PATH)
 
-    if not os.path.exists(nprompter.cli.defaults.DEFAULT_CONFIG_PATH) or override:
-        with open(nprompter.cli.defaults.DEFAULT_CONFIG_PATH, "w") as writable:
+    if not os.path.exists(config_path) or override:
+        with open(config_path, "w") as writable:
             writable.write(config)
+        success(f"Configuration file created: {config_path}")
+        verbose(f"File location: {os.path.abspath(config_path)}")
     else:
-        print(
-            f"The file {nprompter.cli.defaults.DEFAULT_CONFIG_PATH} "
-            "already exists, call this program with the --override flag to override"
-        )
+        warning(f"The file {config_path} already exists. " "Use the --override flag to replace it.")
+        raise typer.Exit(code=1)

--- a/nprompter/cli/output.py
+++ b/nprompter/cli/output.py
@@ -1,0 +1,159 @@
+"""
+Output utilities for CLI commands with verbosity control.
+
+This module provides a centralized way to handle output with different verbosity levels:
+- QUIET: Only errors and critical messages
+- NORMAL: Standard output (info, warnings, errors)
+- VERBOSE: Detailed output including progress and debug info
+- DEBUG: Very detailed output with all debug information
+"""
+
+from enum import IntEnum
+from typing import Optional
+
+import typer
+
+
+class VerbosityLevel(IntEnum):
+    """Verbosity levels for CLI output."""
+
+    QUIET = 0
+    NORMAL = 1
+    VERBOSE = 2
+    DEBUG = 3
+
+
+class OutputHandler:
+    """Handles output with verbosity control."""
+
+    def __init__(self, verbosity: VerbosityLevel = VerbosityLevel.NORMAL):
+        self.verbosity = verbosity
+
+    def set_verbosity(self, verbosity: VerbosityLevel):
+        """Set the verbosity level."""
+        self.verbosity = verbosity
+
+    def error(self, message: str, err: Optional[Exception] = None):
+        """Print an error message (always shown, even in quiet mode)."""
+        typer.echo(typer.style(f"Error: {message}", fg="red"), err=True)
+        if err and self.verbosity >= VerbosityLevel.DEBUG:
+            typer.echo(typer.style(f"  {type(err).__name__}: {err}", fg="red"), err=True)
+
+    def warning(self, message: str):
+        """Print a warning message (shown in normal mode and above)."""
+        if self.verbosity >= VerbosityLevel.NORMAL:
+            typer.echo(typer.style(f"Warning: {message}", fg="yellow"), err=True)
+
+    def info(self, message: str):
+        """Print an informational message (shown in normal mode and above)."""
+        if self.verbosity >= VerbosityLevel.NORMAL:
+            typer.echo(message)
+
+    def success(self, message: str):
+        """Print a success message (shown in normal mode and above)."""
+        if self.verbosity >= VerbosityLevel.NORMAL:
+            typer.echo(typer.style(message, fg="green"))
+
+    def verbose(self, message: str):
+        """Print a verbose message (shown in verbose mode and above)."""
+        if self.verbosity >= VerbosityLevel.VERBOSE:
+            typer.echo(typer.style(f"  → {message}", fg="blue"))
+
+    def debug(self, message: str):
+        """Print a debug message (shown in debug mode only)."""
+        if self.verbosity >= VerbosityLevel.DEBUG:
+            typer.echo(typer.style(f"  [DEBUG] {message}", fg="cyan"), err=True)
+
+    def progress(self, message: str):
+        """Print a progress message (shown in verbose mode and above)."""
+        if self.verbosity >= VerbosityLevel.VERBOSE:
+            typer.echo(typer.style(f"  • {message}", fg="magenta"))
+
+    def echo(self, message: str, force: bool = False):
+        """
+        Print a message directly.
+
+        Args:
+            message: The message to print
+            force: If True, print even in quiet mode
+        """
+        if force or self.verbosity >= VerbosityLevel.NORMAL:
+            typer.echo(message)
+
+
+# Global output handler instance
+_output_handler: Optional[OutputHandler] = None
+
+
+def get_output_handler() -> OutputHandler:
+    """Get the global output handler instance."""
+    global _output_handler
+    if _output_handler is None:
+        _output_handler = OutputHandler()
+    return _output_handler
+
+
+def set_verbosity(verbosity: VerbosityLevel):
+    """Set the global verbosity level."""
+    get_output_handler().set_verbosity(verbosity)
+
+
+def parse_verbosity(quiet: bool, verbose: int) -> VerbosityLevel:
+    """
+    Parse verbosity from CLI flags.
+
+    Args:
+        quiet: If True, return QUIET level
+        verbose: Number of -v flags (0, 1, or 2+)
+
+    Returns:
+        The appropriate VerbosityLevel
+    """
+    if quiet:
+        return VerbosityLevel.QUIET
+    if verbose == 0:
+        return VerbosityLevel.NORMAL
+    if verbose == 1:
+        return VerbosityLevel.VERBOSE
+    return VerbosityLevel.DEBUG
+
+
+# Convenience functions that use the global handler
+def error(message: str, err: Optional[Exception] = None):
+    """Print an error message."""
+    get_output_handler().error(message, err)
+
+
+def warning(message: str):
+    """Print a warning message."""
+    get_output_handler().warning(message)
+
+
+def info(message: str):
+    """Print an informational message."""
+    get_output_handler().info(message)
+
+
+def success(message: str):
+    """Print a success message."""
+    get_output_handler().success(message)
+
+
+def verbose(message: str):
+    """Print a verbose message."""
+    get_output_handler().verbose(message)
+
+
+def debug(message: str):
+    """Print a debug message."""
+    get_output_handler().debug(message)
+
+
+def progress(message: str):
+    """Print a progress message."""
+    get_output_handler().progress(message)
+
+
+def echo(message: str, force: bool = False):
+    """Print a message directly."""
+    get_output_handler().echo(message, force)

--- a/nprompter/processing/processor.py
+++ b/nprompter/processing/processor.py
@@ -1,4 +1,3 @@
-import logging
 import shutil
 from importlib.resources import files
 from pathlib import Path
@@ -9,6 +8,7 @@ from slugify import slugify
 
 import nprompter
 from nprompter.api.notion_client import NotionClient
+from nprompter.cli.output import verbose, warning
 
 
 class HtmlNotionProcessor:
@@ -30,7 +30,6 @@ class HtmlNotionProcessor:
         self.script_template = self.env.get_template("script.html")
         self.index_template = self.env.get_template("database_index.html")
         self.global_index_template = self.env.get_template("global_index.html")
-        self.logger = logging.getLogger("NotionProcessor")
         self.configuration = configuration or {}
         self.custom_css = []
         self.extra_html = configuration.get("build", {}).get("extra_html", None)
@@ -179,13 +178,13 @@ class HtmlNotionProcessor:
                 block_contents.append(f"<p>${expression}$</p>")
             elif block_type == "divider":
                 if self.configuration["processor"]["skip_on_break"]:
-                    self.logger.info("Found divider, stopping block processing")
+                    verbose("Found divider, stopping block processing")
                     break
                 else:
                     block_contents.append("<hr />")
             elif block_type == "code":
                 if self.configuration["processor"]["render_code"] == "skip":
-                    self.logger.info("Found code block, don't render")
+                    verbose("Found code block, don't render")
                 elif self.configuration["processor"]["render_code"] == "placeholder":
                     block_contents.append("<p>⚠ Code block ⚠</p>")
                 elif self.configuration["processor"]["render_code"] == "render":
@@ -193,11 +192,11 @@ class HtmlNotionProcessor:
                     block_contents.append(block["code"]["rich_text"][0]["plain_text"])
                     block_contents.append("</pre>")
                 else:
-                    self.logger.warning("Invalid configuration for render_code")
+                    warning("Invalid configuration for render_code")
             else:
                 block_contents.append(f"<p>⚠ {block['type']} ⚠</p>")
                 block_contents.append(f"<!-- Block of type {block['type']} is not currently supported by Nprompter -->")
-                self.logger.warning(f"Block of type {block['type']} is not currently supported by Nprompter")
+                warning(f"Block of type {block['type']} is not currently supported by Nprompter")
 
         return block_contents
 


### PR DESCRIPTION
This pull request introduces a comprehensive verbosity control system to the `nprompter` CLI, allowing users to adjust the level of output detail using `--quiet` and multiple `--verbose` flags across all commands. It also centralises output handling, replaces direct print/logging statements with new output functions, and updates the documentation to reflect these changes.

The most important changes are:

**Verbosity and Output Control:**

* Introduced a new `nprompter.cli.output` module that provides a global output handler with support for multiple verbosity levels (`QUIET`, `NORMAL`, `VERBOSE`, `DEBUG`). This module offers standardised functions such as `info`, `warning`, `error`, `success`, `verbose`, `debug`, and `progress` for consistent CLI messaging.
* Updated all CLI commands in `nprompter/__main__.py` (`build`, `serve`, and `create_config`) to accept `--quiet`/`-q` and `--verbose`/`-v` flags, and to use the new output functions for all user-facing messages and errors.
* Replaced legacy logging and print statements in `nprompter/processing/processor.py` with the new output functions, ensuring all output respects the selected verbosity level. 

**Documentation Updates:**

* Updated `docs/nprompter/usage.md` to document the new `--quiet` and `--verbose` flags for all commands, and added a reference to additional verbosity documentation.

**CLI Option Consistency:**

* **BREAKING CHANGE**: Removed the `-v` short flag from the `--value` option (now only `--value`), and from `--extra-css` (now only `--extra-css`), to avoid conflicts with the new `-v/--verbose` flag. 

These changes make the CLI output more user-friendly and customizable, and improve the maintainability of output-related code.