### PR TITLE
Replace non breaking chars and allow meta keys

### DIFF
--- a/docs/nprompter/configuration-file.md
+++ b/docs/nprompter/configuration-file.md
@@ -14,6 +14,8 @@ family = "'Roboto', sans-serif"
 [processor]
 skip_on_break = false
 hide_non_default_colors = false
+skip_square_brackets = false
+replace_nbsp = true
 render_code = "placeholder"
 
 [screen]

--- a/nprompter/processing/processor.py
+++ b/nprompter/processing/processor.py
@@ -219,6 +219,8 @@ class HtmlNotionProcessor:
                 annotations = content["annotations"]
                 annotations_tags = ["bold", "italic", "strikethrough", "underline", "code"]
                 classes = " ".join(base_classes + [tag for tag in annotations_tags if annotations.get(tag)])
+                if self.configuration["processor"]["replace_nbsp"]:
+                    text_content = text_content.replace(chr(160), " ")
                 tag = f'<span class="{classes}">{text_content}</span>'
                 paragraph_content_tags.append(tag)
             elif equation := content.get("equation"):

--- a/nprompter/web/assets/app.js
+++ b/nprompter/web/assets/app.js
@@ -49,13 +49,13 @@ function scrollToTop() {
 function decreaseSpeed() {
     const scrollSpeed = Math.min(maxScrollSpeed, getSetting("scrollSpeed") + scrollSpeedIncrease);
     saveSetting("scrollSpeed", scrollSpeed)
-    return `Scroll speed: ${scrollSpeed}`
+    return `Scroll speed: ${maxScrollSpeed - scrollSpeed}`
 }
 
-function increaseSpeed() {
+function  increaseSpeed() {
     const scrollSpeed = Math.max(0, getSetting("scrollSpeed") - scrollSpeedIncrease)
     saveSetting("scrollSpeed", scrollSpeed)
-    return `Scroll speed: ${scrollSpeed}`
+    return `Scroll speed: ${maxScrollSpeed - scrollSpeed}`
 }
 
 function setLineHeight(lineHeight) {

--- a/nprompter/web/assets/app.js
+++ b/nprompter/web/assets/app.js
@@ -17,6 +17,9 @@ setMirrored(getSetting("mirrored"))
 
 function logKey(e) {
     const keyCode = e.keyCode;
+    if (e.metaKey) {
+        return;
+    }
     if (handleKeyCode(keyCode)) {
         e.preventDefault();
     }

--- a/nprompter/web/nprompter.toml
+++ b/nprompter/web/nprompter.toml
@@ -10,6 +10,7 @@ family = "'Roboto', sans-serif"
 skip_on_break = false
 hide_non_default_colors = false
 skip_square_brackets = false
+replace_nbsp = true
 render_code = "placeholder"
 
 [screen]

--- a/nprompter/web/templates/base.html
+++ b/nprompter/web/templates/base.html
@@ -40,7 +40,7 @@
                         <div class="key">S</div>
                       </div>
                       <div class="grid-item">
-                        Line width
+                        Line height
                         <div class="key">Z</div>
                         <div class="key">X</div>
                       </div>


### PR DESCRIPTION
This pull request introduces several configuration and processing improvements, as well as minor UI and behaviour adjustments. The most notable change is the addition of a new configuration option for replacing non-breaking spaces, which is now supported in both the configuration files and the text processing logic. There are also updates to keyboard event handling, scroll speed display, and a small correction in the UI label.

**Configuration and Text Processing Improvements:**

* Added the `replace_nbsp` option to both `docs/nprompter/configuration-file.md` and `nprompter/web/nprompter.toml`, allowing users to enable automatic replacement of non-breaking spaces in processed text.
* Updated `nprompter/processing/processor.py` to replace non-breaking spaces with regular spaces in paragraph content when `replace_nbsp` is enabled.

**UI and Behaviour Adjustments:**

* Improved keyboard event handling in `nprompter/web/assets/app.js` by ignoring events when the meta key is pressed, preventing unintended actions.
* Changed the scroll speed display logic in `nprompter/web/assets/app.js` so it now shows `maxScrollSpeed - scrollSpeed` instead of the raw value, making the display more intuitive.
* Corrected a UI label in `nprompter/web/templates/base.html` from "Line width" to "Line height" for clarity.